### PR TITLE
test: add PrivacySandboxViewModel and publisher app tests

### DIFF
--- a/PublisherApp/app/build.gradle
+++ b/PublisherApp/app/build.gradle
@@ -34,6 +34,8 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -75,4 +77,10 @@ dependencies {
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    // unit test dependencies
+    testImplementation "androidx.test:runner:1.6.2"
+
+    // android test dependencies
+    androidTestImplementation "androidx.test:runner:1.6.2"
 }

--- a/PublisherApp/app/src/androidTest/java/com/example/publisherapp/PublisherAppTest.kt
+++ b/PublisherApp/app/src/androidTest/java/com/example/publisherapp/PublisherAppTest.kt
@@ -23,6 +23,7 @@ class PublisherAppTest {
     @Test
     fun privacySandboxViewModel_appContext() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+
         Assert.assertEquals("com.example.publisherapp", appContext.packageName)
     }
 }

--- a/PublisherApp/app/src/androidTest/java/com/example/publisherapp/PublisherAppTest.kt
+++ b/PublisherApp/app/src/androidTest/java/com/example/publisherapp/PublisherAppTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.publisherapp
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert
+import org.junit.Test
+
+class PublisherAppTest {
+    @Test
+    fun privacySandboxViewModel_appContext() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        Assert.assertEquals("com.example.publisherapp", appContext.packageName)
+    }
+}

--- a/PublisherApp/app/src/main/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModel.kt
+++ b/PublisherApp/app/src/main/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModel.kt
@@ -49,7 +49,8 @@ class PrivacySandboxViewModel(
                 subtitle = data.subtitle,
                 author = data.author,
                 metadata = data.metadata,
-                paragraphs = data.paragraphs
+                paragraphs = data.paragraphs,
+                adUrl = data.adUrl
             )
         }
     }

--- a/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
+++ b/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
@@ -36,7 +36,6 @@ class PrivacySandboxViewModelTest {
     fun initializeFromStaticData() {
         // TODO: replace null param with a mocked SspSdkImpl
         val privacySandboxViewModel = PrivacySandboxViewModel(null)
-
         val updatedFields = PageData(
             "my-title",
             "my-subtitle",
@@ -45,9 +44,10 @@ class PrivacySandboxViewModelTest {
             listOf("paragraph-1", "paragraph-2"),
             "my-url"
         )
-        privacySandboxViewModel.initializeFromStaticData(updatedFields)
 
+        privacySandboxViewModel.initializeFromStaticData(updatedFields)
         val updatedUiState = privacySandboxViewModel.uiState.value
+
         Assert.assertEquals(updatedFields, updatedUiState)
     }
 }

--- a/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
+++ b/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
@@ -21,15 +21,21 @@ import org.junit.Test
 
 class PrivacySandboxViewModelTest {
     @Test
-    fun initializeFromStaticData() {
+    fun initialUiState() {
         // TODO: replace null param with a mocked SspSdkImpl
         val privacySandboxViewModel = PrivacySandboxViewModel(null)
-
         val initialUiState = privacySandboxViewModel.uiState.value
+
         // default uninitialized values
         Assert.assertEquals(
             PageData("", "", "", "", listOf(""), null),
             initialUiState)
+    }
+
+    @Test
+    fun initializeFromStaticData() {
+        // TODO: replace null param with a mocked SspSdkImpl
+        val privacySandboxViewModel = PrivacySandboxViewModel(null)
 
         val updatedFields = PageData(
             "my-title",

--- a/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
+++ b/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.publisherapp.viewmodel
+
+import com.example.publisherapp.model.PageData
+import org.junit.Assert
+import org.junit.Test
+
+class PrivacySandboxViewModelTest {
+    @Test
+    fun initializeFromStaticData() {
+        // TODO: replace null param with a mocked SspSdkImpl
+        val privacySandboxViewModel = PrivacySandboxViewModel(null)
+
+        val initialUiState = privacySandboxViewModel.uiState.value
+        // default uninitialized values
+        Assert.assertEquals(
+            PageData("", "", "", "", listOf(""), null),
+            initialUiState)
+
+        val updatedFields = PageData(
+            "my-title",
+            "my-subtitle",
+            "my-author",
+            "my-metadata",
+            listOf("paragraph-1", "paragraph-2"),
+            "my-url"
+        )
+        privacySandboxViewModel.initializeFromStaticData(updatedFields)
+
+        val updatedUiState = privacySandboxViewModel.uiState.value
+        Assert.assertEquals(updatedFields, updatedUiState)
+    }
+}


### PR DESCRIPTION
Adds two basic unit and android tests for both the view model and general publisher app