### PR TITLE
fix: winning ad should be displayed in Publisher app

### DIFF
--- a/PublisherApp/app/src/main/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModel.kt
+++ b/PublisherApp/app/src/main/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModel.kt
@@ -49,8 +49,7 @@ class PrivacySandboxViewModel(
                 subtitle = data.subtitle,
                 author = data.author,
                 metadata = data.metadata,
-                paragraphs = data.paragraphs,
-                adUrl = data.adUrl
+                paragraphs = data.paragraphs
             )
         }
     }

--- a/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
+++ b/PublisherApp/app/src/test/java/com/example/publisherapp/viewmodel/PrivacySandboxViewModelTest.kt
@@ -41,8 +41,7 @@ class PrivacySandboxViewModelTest {
             "my-subtitle",
             "my-author",
             "my-metadata",
-            listOf("paragraph-1", "paragraph-2"),
-            "my-url"
+            listOf("paragraph-1", "paragraph-2")
         )
 
         privacySandboxViewModel.initializeFromStaticData(updatedFields)


### PR DESCRIPTION
A recent update to the code resulted in the winning ad not getting shown in the Publisher app. There is a call to `initializeFromStaticData` after the `init` occurs, which causes the result from `retrieveAd()` to be overwritten with a blank URL. This change fixes that issue.